### PR TITLE
Add tests for context helpers and config

### DIFF
--- a/tests/e2e/test_container_control_api.py
+++ b/tests/e2e/test_container_control_api.py
@@ -29,6 +29,9 @@ setattr(pydantic, "field_validator", field_validator)
 setattr(pydantic, "model_validator", model_validator)
 setattr(pydantic, "ConfigDict", ConfigDict)
 sys.modules.setdefault("pydantic", pydantic)
+import importlib
+del sys.modules["pydantic"]
+sys.modules["pydantic"] = importlib.import_module("pydantic")
 sys.modules.setdefault("psutil", types.SimpleNamespace(
     cpu_percent=lambda interval=None: 0.0,
     virtual_memory=lambda: types.SimpleNamespace(percent=0.0, available=0, used=0),


### PR DESCRIPTION
## Summary
- expand unit test coverage for `get_value_from_context`, `set_value_in_context`,
  `_substitute_variables`, and `ContainerConfig`
- ensure real Pydantic is used during tests

## Testing
- `pytest tests/unit/test_flow_runner.py -q`