### PR TITLE
Allow numeric flowmap id

### DIFF
--- a/flow_runner.py
+++ b/flow_runner.py
@@ -136,7 +136,13 @@ ConditionStep.model_rebuild()
 LoopStep.model_rebuild()
 
 class FlowMap(BaseModel):
-    id: Optional[str] = Field(None, description="Unique ID of the flowmap (optional, used for updates)") # Added ID field
+    id: Optional[str | int] = Field(
+        None,
+        description=(
+            "Unique ID of the flowmap (optional, used for updates). "
+            "May be numeric when supplied by external tooling."
+        ),
+    )
     name: str = Field(..., description="Name of the flow")
     description: Optional[str] = Field(None, description="Description of the flow")
     headers: Optional[Dict[str, str]] = Field(default_factory=dict, description="Global headers applied to all requests in the flow. Can contain {{variables}}.")

--- a/tests/unit/test_flow_runner.py
+++ b/tests/unit/test_flow_runner.py
@@ -77,6 +77,11 @@ def make_runner(config: ContainerConfig, flow: FlowMap) -> FlowRunner:
     return runner
 
 
+def test_flowmap_accepts_numeric_id():
+    fm = FlowMap(id=12345, name="test", steps=[], staticVars={})
+    assert fm.id == 12345
+
+
 def test_init_override_step_url_host_default(base_config, empty_flow):
     runner = make_runner(base_config, empty_flow)
     assert runner.config.override_step_url_host is True


### PR DESCRIPTION
## Summary
- allow integer `id` in `FlowMap`
- test numeric id parsing

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_684140aa0b608320b8553dd7eb4187b9