### PR TITLE
Add flow_cycle_delay_ms option

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ FlowRunner is designed to execute flows exported from a companion graphical flow
     *   **Global Target URL:** Configure a primary base URL for all flow operations.
     *   **DNS Override:** Optionally override DNS resolution for the global target URL.
     *   **Override Step URL Host:** By default the host of every request comes from `flow_target_url`, with the step providing only path/query. Disable with `override_step_url_host: false`.
+    *   **Flow Cycle Delay:** Optionally specify a fixed wait time between flow iterations via `flow_cycle_delay_ms`.
 *   **Context Management:**
     *   Maintains an execution context that evolves as the flow progresses.
     *   Ensures context isolation for loop iterations.
@@ -83,6 +84,7 @@ Starts (or restarts) the FlowRunner with the provided configuration and flowmap.
     "max_sleep_ms": "integer (default: 1000, max ms between steps)",
     "debug": "boolean (default: false, enables verbose logging)"
     "override_step_url_host": "boolean (default: true, ignore host in step URLs)"
+    "flow_cycle_delay_ms": "integer (optional, fixed ms wait between flow cycles)"
     // Any other fields defined in ContainerConfig Pydantic model
   },
   "flowmap": {

--- a/tests/unit/test_flow_runner.py
+++ b/tests/unit/test_flow_runner.py
@@ -619,6 +619,15 @@ def test_container_config_alias_override_step_url_host():
     assert cfg.override_step_url_host is False
 
 
+def test_container_config_alias_flow_cycle_delay_ms():
+    cfg = ContainerConfig(
+        flow_target_url="http://example.com",
+        sim_users=1,
+        **{"Flow Cycle Delay MS": 1500},
+    )
+    assert cfg.flow_cycle_delay_ms == 1500
+
+
 def test_container_config_validation_errors():
     pydantic = sys.modules["pydantic"]
     with pytest.raises(pydantic.ValidationError):


### PR DESCRIPTION
## Summary
- allow fixed sleep between flow iterations via new ContainerConfig option `flow_cycle_delay_ms`
- document the option in README
- test alias handling for `flow_cycle_delay_ms`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_68428b02d6008320a293d2c198258dd6