### PR TITLE
Add cycle delay option to local runner script

### DIFF
--- a/README.md
+++ b/README.md
@@ -351,10 +351,10 @@ Refer to the provided `Dockerfile` and `requirements.txt`.
 For quick local debugging of `flow_runner.py` without Docker, use the provided `run_local_flow.sh` script:
 
 ```bash
-./run_local_flow.sh path/to/flow.json [target_url] [sim_users] [DEBUG|INFO]
+./run_local_flow.sh path/to/flow.json [target_url] [sim_users] [DEBUG|INFO] [cycle_delay_ms]
 ```
 
-This executes the flow directly with a local Python interpreter. Stop with `Ctrl+C` when finished.
+This executes the flow directly with a local Python interpreter. Pass `cycle_delay_ms` to set a fixed delay between flow iterations (equivalent to the `--cycle-delay-ms` flag). Stop with `Ctrl+C` when finished.
 
 ## 8. Logging
 

--- a/flow_runner_direct_invoker.py
+++ b/flow_runner_direct_invoker.py
@@ -13,6 +13,13 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument("flow_url", nargs="?", default="http://localhost:8000", help="Base URL for flow target")
     parser.add_argument("sim_users", nargs="?", type=int, default=1, help="Number of simulated users")
     parser.add_argument("debug_level", nargs="?", default="INFO", help="Logging level (DEBUG, INFO, WARNING)")
+    parser.add_argument(
+        "--cycle-delay-ms",
+        dest="cycle_delay_ms",
+        type=int,
+        default=None,
+        help="Fixed delay between flow iterations in milliseconds",
+    )
     return parser.parse_args()
 
 
@@ -38,6 +45,7 @@ def main() -> None:
         flow_target_url=args.flow_url,
         sim_users=args.sim_users,
         debug=args.debug_level.upper() == "DEBUG",
+        flow_cycle_delay_ms=args.cycle_delay_ms,
     )
 
     loop = asyncio.new_event_loop()

--- a/run_local_flow.sh
+++ b/run_local_flow.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 if [ -z "$1" ]; then
-  echo "Usage: $0 <path_to_flow_file.json> [flow_target_url] [sim_users] [debug_level]" >&2
+  echo "Usage: $0 <path_to_flow_file.json> [flow_target_url] [sim_users] [debug_level] [cycle_delay_ms]" >&2
   exit 1
 fi
 
@@ -9,8 +9,13 @@ FLOW_FILE="$1"
 FLOW_URL="${2:-http://localhost:8000}"
 SIM_USERS="${3:-1}"
 DEBUG_LEVEL="${4:-INFO}"
+CYCLE_DELAY_MS="$5"
 
 SCRIPT_DIR="$(dirname "$0")"
 PYTHON_SCRIPT="$SCRIPT_DIR/flow_runner_direct_invoker.py"
 
-python3 "$PYTHON_SCRIPT" "$FLOW_FILE" "$FLOW_URL" "$SIM_USERS" "$DEBUG_LEVEL"
+if [ -n "$CYCLE_DELAY_MS" ]; then
+  python3 "$PYTHON_SCRIPT" "$FLOW_FILE" "$FLOW_URL" "$SIM_USERS" "$DEBUG_LEVEL" --cycle-delay-ms "$CYCLE_DELAY_MS"
+else
+  python3 "$PYTHON_SCRIPT" "$FLOW_FILE" "$FLOW_URL" "$SIM_USERS" "$DEBUG_LEVEL"
+fi


### PR DESCRIPTION
## Summary
- extend `parse_args()` in `flow_runner_direct_invoker.py` with `--cycle-delay-ms`
- pass the new value into `ContainerConfig`
- update `run_local_flow.sh` to forward an optional cycle delay argument
- document the flag in the README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_68428ff5e6448320883ac371b36b71ee