### PR TITLE
Add run_once flag and min/max step delay control

### DIFF
--- a/README.md
+++ b/README.md
@@ -351,10 +351,14 @@ Refer to the provided `Dockerfile` and `requirements.txt`.
 For quick local debugging of `flow_runner.py` without Docker, use the provided `run_local_flow.sh` script:
 
 ```bash
-./run_local_flow.sh path/to/flow.json [target_url] [sim_users] [DEBUG|INFO] [cycle_delay_ms]
+./run_local_flow.sh path/to/flow.json [target_url] [sim_users] [DEBUG|INFO] [cycle_delay_ms] [--min-step-ms N] [--max-step-ms N] [--run-once]
 ```
 
-This executes the flow directly with a local Python interpreter. Pass `cycle_delay_ms` to set a fixed delay between flow iterations (equivalent to the `--cycle-delay-ms` flag). Stop with `Ctrl+C` when finished.
+This executes the flow directly with a local Python interpreter. Optional flags allow fine-grained control:
+- `--cycle-delay-ms` sets a fixed delay between flow iterations.
+- `--min-step-ms`/`--max-step-ms` override the standard min/max step delay.
+- `--run-once` runs the flow a single time and then exits.
+Stop with `Ctrl+C` when finished.
 
 ## 8. Logging
 

--- a/run_local_flow.sh
+++ b/run_local_flow.sh
@@ -1,7 +1,39 @@
 #!/bin/bash
 
+usage() {
+  echo "Usage: $0 <path_to_flow_file.json> [flow_target_url] [sim_users] [debug_level] [cycle_delay_ms] [--min-step-ms N] [--max-step-ms N] [--run-once]" >&2
+}
+
+POSITIONAL=()
+MIN_STEP_MS=""
+MAX_STEP_MS=""
+RUN_ONCE="false"
+
+while [[ $# -gt 0 ]]; do
+  case $1 in
+    --min-step-ms)
+      MIN_STEP_MS="$2"
+      shift 2
+      ;;
+    --max-step-ms)
+      MAX_STEP_MS="$2"
+      shift 2
+      ;;
+    --run-once)
+      RUN_ONCE="true"
+      shift
+      ;;
+    *)
+      POSITIONAL+=("$1")
+      shift
+      ;;
+  esac
+done
+
+set -- "${POSITIONAL[@]}"
+
 if [ -z "$1" ]; then
-  echo "Usage: $0 <path_to_flow_file.json> [flow_target_url] [sim_users] [debug_level] [cycle_delay_ms]" >&2
+  usage
   exit 1
 fi
 
@@ -14,8 +46,19 @@ CYCLE_DELAY_MS="$5"
 SCRIPT_DIR="$(dirname "$0")"
 PYTHON_SCRIPT="$SCRIPT_DIR/flow_runner_direct_invoker.py"
 
+CMD=(python3 "$PYTHON_SCRIPT" "$FLOW_FILE" "$FLOW_URL" "$SIM_USERS" "$DEBUG_LEVEL")
+
 if [ -n "$CYCLE_DELAY_MS" ]; then
-  python3 "$PYTHON_SCRIPT" "$FLOW_FILE" "$FLOW_URL" "$SIM_USERS" "$DEBUG_LEVEL" --cycle-delay-ms "$CYCLE_DELAY_MS"
-else
-  python3 "$PYTHON_SCRIPT" "$FLOW_FILE" "$FLOW_URL" "$SIM_USERS" "$DEBUG_LEVEL"
+  CMD+=(--cycle-delay-ms "$CYCLE_DELAY_MS")
 fi
+if [ -n "$MIN_STEP_MS" ]; then
+  CMD+=(--min-step-ms "$MIN_STEP_MS")
+fi
+if [ -n "$MAX_STEP_MS" ]; then
+  CMD+=(--max-step-ms "$MAX_STEP_MS")
+fi
+if [ "$RUN_ONCE" = "true" ]; then
+  CMD+=(--run-once)
+fi
+
+"${CMD[@]}"


### PR DESCRIPTION
## Summary
- allow overriding min/max step delay when running locally
- add `--min-step-ms` and `--max-step-ms` in run scripts
- expose same options in `flow_runner_direct_invoker.py`
- keep `--run-once` support

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'container_control')*

------
https://chatgpt.com/codex/tasks/task_b_6877641d808c8320a44b6d861a935ba9