### PR TITLE
Update to v1.1.3 and add release notes

### DIFF
--- a/README.md
+++ b/README.md
@@ -308,7 +308,7 @@ Defines iteration over a list.
 
 *   Inside the loop `steps`, `{{loopVariable}}` (e.g., `{{item}}`) and `{{loopVariable_index}}` will be available in the context.
 
-### 5.3. URL Construction Logic (Version 1.1.0 Behavior)
+### 5.3. URL Construction Logic (Version 1.1.3 Behavior)
 
 The final URL for each Request step depends on `override_step_url_host`:
 
@@ -322,7 +322,7 @@ The final URL for each Request step depends on `override_step_url_host`:
     *   If it is relative, it is appended to `flow_target_url`.
 4.  **DNS Override:** When `flow_target_dns_override` is set, requests are directed to that IP while the `Host` header reflects the original hostname.
 
-**URL Override Update (v1.1.0):** `config.override_step_url_host` now controls how final request URLs are built. When `true` (default) the scheme/host/port come exclusively from `flow_target_url` and the step only provides the path/query. Set to `false` to allow absolute step URLs as in v1.0.0.
+**URL Override Update (v1.1.3):** `config.override_step_url_host` now controls how final request URLs are built. When `true` (default) the scheme/host/port come exclusively from `flow_target_url` and the step only provides the path/query. Set to `false` to allow absolute step URLs as in v1.0.0.
 
 ## 6. Deployment & Usage (Docker)
 
@@ -330,11 +330,11 @@ Refer to the provided `Dockerfile` and `requirements.txt`.
 
 1.  **Build the Docker Image:**
     ```bash
-    docker build -t flowrunner-engine:1.1.0 .
+    docker build -t flowrunner-engine:1.1.3 .
     ```
 2.  **Run the Container:**
     ```bash
-    docker run -d -p 8080:8080 --name my-flowrunner flowrunner-engine:1.1.0
+    docker run -d -p 8080:8080 --name my-flowrunner flowrunner-engine:1.1.3
     ```
     *   The API will be available on `http://localhost:8080`.
     *   Consider volume mounting for persistent configurations or logs if needed.

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,0 +1,10 @@
+# Release Notes: FlowRunner CLI v1.1.3
+
+## Highlights
+
+- **Container Control Core v2.0 integration** for unified lifecycle management and API endpoints.
+- **Run once and step delay overrides** via updated `run_local_flow.sh` script and direct invoker.
+- **Enhanced release pipeline** with GitHub workflow updates.
+- **Documentation updates** and improved local execution options.
+
+This release aligns the CLI with the latest Container Control capabilities while giving operators more control when executing flows locally. See the README for detailed usage instructions.

--- a/flow_runner.py
+++ b/flow_runner.py
@@ -622,7 +622,7 @@ class FlowRunner:
             {"Accept": "application/vnd.api+json", "Connection": "keep-alive", "Authorization": "Bearer random_api_token", "X-API-Version": "2.0", "Accept-Encoding": "gzip, deflate, br"},
             {"Accept": "application/ld+json", "Connection": "keep-alive", "X-Correlation-ID": "some_correlation_id", "Content-Type": "application/json", "Accept-Encoding": "gzip, deflate"},
             {"Accept": "text/csv", "Connection": "keep-alive", "X-Auth-Token": "some_auth_token", "Accept-Encoding": "gzip, deflate, br", "Content-Type": "text/csv"},
-            {"Accept": "application/x-www-form-urlencoded", "Connection": "keep-alive", "Accept-Encoding": "gzip, deflate", "X-Client-Version": "1.1.0", "Content-Type": "application/x-www-form-urlencoded"},
+            {"Accept": "application/x-www-form-urlencoded", "Connection": "keep-alive", "Accept-Encoding": "gzip, deflate", "X-Client-Version": "1.1.3", "Content-Type": "application/x-www-form-urlencoded"},
             {"Accept": "application/protobuf", "Connection": "keep-alive", "Content-Type": "application/protobuf", "Accept-Encoding": "gzip, deflate"},
             {"Accept": "application/octet-stream", "Connection": "keep-alive", "Content-Type": "application/octet-stream", "Accept-Encoding": "gzip, deflate, br"},
             {"Accept": "application/graphql", "Connection": "keep-alive", "Content-Type": "application/graphql", "Accept-Encoding": "gzip, deflate"},

--- a/roadmap.md
+++ b/roadmap.md
@@ -254,7 +254,7 @@ By meticulously addressing these points, the AI agent can successfully upgrade t
 
 ## Project Roadmap
 
-### v1.1.0 (Current)
+### v1.1.3 (Current)
 
 - [x] **Continuous Flow Runner (Simplified):** FlowRunner now runs indefinitely when started via the API and resets context between iterations.
 - [x] **Validation & Error Handling Improvements:** API responses and internal logging provide clearer details on invalid configurations and flow errors.

--- a/testplan.md
+++ b/testplan.md
@@ -4,7 +4,7 @@ Okay, here's a comprehensive Markdown document mapping out unit and end-to-end (
 
 # Test Plan: `flow_runner.py` (Dockerized FlowRunner) & `container_control.py`
 
-**Version:** 1.1
+**Version:** 1.1.3
 **Date:** August 2nd, 2024
 **Purpose:** To outline a comprehensive suite of unit and end-to-end (E2E) tests for the `flow_runner.py` module and its `container_control.py` API interface. This plan aims to ensure functional correctness, robustness, and alignment with specified behaviors, including recent enhancements.
 


### PR DESCRIPTION
## Summary
- add release notes for FlowRunner CLI 1.1.3
- update version references to 1.1.3 in documentation and code

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'container_control')*

------
https://chatgpt.com/codex/tasks/task_b_68776974d02883209179f37ea5f71a4d