### PR TITLE
feat: support multiple flowmaps

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ The FlowRunner system consists of two main Python files typically run within a D
 2.  **`container_control.py`:**
     *   Provides a FastAPI-based HTTP API to manage and interact with the `FlowRunner` instance.
     *   Endpoints:
-        *   `/api/start`: To initiate flow execution with a given configuration and flowmap.
+        *   `/api/start`: To initiate flow execution with a given configuration and flowmap or flowmaps.
         *   `/api/stop`: To immediately halt any ongoing flow execution.
         *   `/api/health`: Basic health check.
         *   `/api/metrics`: Detailed operational metrics in JSON format.
@@ -66,7 +66,7 @@ All endpoints are prefixed with `/api` unless otherwise noted.
 
 ### 4.1. `POST /api/start`
 
-Starts (or restarts) the FlowRunner with the provided configuration and flowmap. If a flow is already running, it will be forcibly stopped before the new one begins.
+Starts (or restarts) the FlowRunner with the provided configuration and flowmap(s). If a flow is already running, it will be forcibly stopped before the new one begins.
 
 **Request Body (JSON):**
 
@@ -88,8 +88,13 @@ Starts (or restarts) the FlowRunner with the provided configuration and flowmap.
     // Any other fields defined in ContainerConfig Pydantic model
   },
   "flowmap": {
-    // JSON object representing the flow definition. See Section 5 for FlowMap structure.
+    // JSON object representing a single flow definition
   }
+  // or
+  "flowmaps": [
+    { /* first flow */ },
+    { /* second flow */ }
+  ]
 }
 ```
 

--- a/flowrunner_adapter.py
+++ b/flowrunner_adapter.py
@@ -38,20 +38,12 @@ class FlowRunnerAdapter(ApplicationAdapter):
 
     def start(self, start_payload: Dict[str, Any], *, ensure_user) -> Any:
         """
-        Start FlowRunner with the provided configuration and flowmap.
-        
+        Start FlowRunner with the provided configuration and flowmap(s).
+
         Expected payload structure:
         {
-            "config": {
-                "flow_target_url": "http://example.com",
-                "sim_users": 10,
-                "debug": false,
-                ...
-            },
-            "flowmap": {
-                "steps": [...],
-                ...
-            }
+            "config": { ... },
+            "flowmap": { ... } | "flowmaps": [ {...}, {...} ]
         }
         """
         logger.info("Starting FlowRunner with payload")
@@ -202,6 +194,7 @@ class FlowRunnerAdapter(ApplicationAdapter):
             self.flow_runner = FlowRunner(
                 config=start_request.config,
                 flowmap=start_request.flowmap,
+                flowmaps=start_request.flowmaps,
                 metrics=self.metrics
             )
             

--- a/tests/unit/test_flow_runner.py
+++ b/tests/unit/test_flow_runner.py
@@ -44,6 +44,7 @@ import pytest
 import logging
 import aiohttp
 import copy
+from pydantic import ValidationError
 
 from flow_runner import (
     FlowRunner,
@@ -54,6 +55,7 @@ from flow_runner import (
     ConditionStep,
     ConditionData,
     Metrics,
+    StartRequest,
     get_value_from_context, _MISSING, set_value_in_context,
 )
 
@@ -80,6 +82,16 @@ def make_runner(config: ContainerConfig, flow: FlowMap) -> FlowRunner:
 def test_flowmap_accepts_numeric_id():
     fm = FlowMap(id=12345, name="test", steps=[], staticVars={})
     assert fm.id == 12345
+
+
+def test_start_request_with_flowmaps(base_config, empty_flow):
+    sr = StartRequest(config=base_config, flowmaps=[empty_flow])
+    assert sr.flowmaps is not None and sr.flowmap is None
+
+
+def test_start_request_requires_flow(base_config):
+    with pytest.raises(ValidationError):
+        StartRequest(config=base_config)
 
 
 def test_init_override_step_url_host_default(base_config, empty_flow):


### PR DESCRIPTION
## Summary
- allow `/api/start` payload to provide either a single `flowmap` or multiple `flowmaps`
- iterate through all provided flowmaps once per simulated user
- document new `flowmaps` payload option and add unit tests for validation

## Testing
- `pytest` *(fails: No module named 'container_control')*

------
https://chatgpt.com/codex/tasks/task_b_68b49d7c53c0832094f86f364a9cf5a3