### PR TITLE
Ensure flows continue after step failure

### DIFF
--- a/flow_runner.py
+++ b/flow_runner.py
@@ -2036,45 +2036,66 @@ class FlowRunner:
 
             connector = self.create_aiohttp_connector()
 
-            flows = list(self.flowmaps)
-            random.shuffle(flows)
+            overall_flow_iteration = 0
+            while self.running:
+                flows = list(self.flowmaps)
+                random.shuffle(flows)
 
-            for flow_iteration, flow in enumerate(flows, start=1):
-                if not self.running:
-                    break
-                flow_instance_start_time = time.monotonic()
-                flow_epoch_start_time = time.time()
+                for flow_iteration, flow in enumerate(flows, start=1):
+                    if not self.running:
+                        break
+                    overall_flow_iteration += 1
+                    flow_instance_start_time = time.monotonic()
+                    flow_epoch_start_time = time.time()
 
-                fake_ip = self.generate_random_ip()
-                is_web_like = random.choice([True, False])
-                chosen_headers_template = random.choice(self.headers_web_options if is_web_like else self.headers_api_options)
-                if not isinstance(chosen_headers_template, dict):
-                    logger.error(f"{user_log_prefix} (Flow {flow_iteration}): Invalid header template found: {chosen_headers_template}. Using empty headers.")
-                    base_session_headers = {}
-                else:
-                    base_session_headers = chosen_headers_template.copy()
+                    fake_ip = self.generate_random_ip()
+                    is_web_like = random.choice([True, False])
+                    chosen_headers_template = random.choice(
+                        self.headers_web_options if is_web_like else self.headers_api_options
+                    )
+                    if not isinstance(chosen_headers_template, dict):
+                        logger.error(
+                            f"{user_log_prefix} (Flow {flow_iteration}): Invalid header template found: {chosen_headers_template}. Using empty headers."
+                        )
+                        base_session_headers = {}
+                    else:
+                        base_session_headers = chosen_headers_template.copy()
 
-                ua_template = random.choice(self.user_agents_web if is_web_like else self.user_agents_api)
-                ua = ua_template if isinstance(ua_template, str) else "FlowRunner/1.0"
-                base_session_headers["User-Agent"] = ua
-                if self.config.xff_header_name:
-                    base_session_headers[self.config.xff_header_name] = fake_ip
-                logger.debug(f"{user_log_prefix} (Flow {flow_iteration}): New session state (IP: {fake_ip}, UA: {ua[:30]}..., Profile: {'Web' if is_web_like else 'API'})")
+                    ua_template = random.choice(
+                        self.user_agents_web if is_web_like else self.user_agents_api
+                    )
+                    ua = ua_template if isinstance(ua_template, str) else "FlowRunner/1.0"
+                    base_session_headers["User-Agent"] = ua
+                    if self.config.xff_header_name:
+                        base_session_headers[self.config.xff_header_name] = fake_ip
+                    logger.debug(
+                        f"{user_log_prefix} (Flow {flow_iteration}): New session state (IP: {fake_ip}, UA: {ua[:30]}..., Profile: {'Web' if is_web_like else 'API'})"
+                    )
 
-                context = {
-                    "userId": user_id,
-                    "userFakeIp": fake_ip,
-                    "flowInstance": flow_iteration,
-                    "flowStartTimeEpoch": flow_epoch_start_time,
-                    "flow_error": None,
-                }
-                static_vars = getattr(flow, 'staticVars', {})
-                if static_vars:
-                    try:
-                        context.update(copy.deepcopy(static_vars))
-                    except Exception as copy_err:
-                        logger.warning(f"{user_log_prefix} (Flow {flow_iteration}): Could not deepcopy staticVars: {copy_err}. Using shallow copy.")
-                        context.update(static_vars)
+                    context = {
+                        "userId": user_id,
+                        "userFakeIp": fake_ip,
+                        "flowInstance": overall_flow_iteration,
+                        "flowStartTimeEpoch": flow_epoch_start_time,
+                        "flow_error": None,
+                    }
+                    static_vars = getattr(flow, 'staticVars', {})
+                    if static_vars:
+                        try:
+                            context.update(copy.deepcopy(static_vars))
+                        except Exception as copy_err:
+                            logger.warning(
+                                f"{user_log_prefix} (Flow {flow_iteration}): Could not deepcopy staticVars: {copy_err}. Using shallow copy."
+                            )
+                            context.update(static_vars)
+
+                    if self.on_iteration_start and overall_flow_iteration > 1:
+                        try:
+                            self.on_iteration_start(overall_flow_iteration, context.copy())
+                        except Exception as cb_err:
+                            logger.warning(
+                                f"{user_log_prefix} (Flow {overall_flow_iteration}): on_iteration_start callback error: {cb_err}"
+                            )
 
                 global_flow_headers_def = getattr(flow, 'headers', {}) or {}
 
@@ -2119,24 +2140,24 @@ class FlowRunner:
                     elif not self.running:
                         logger.info(f"{user_log_prefix} (Flow {flow_iteration}): Flow ended after {flow_duration:.3f} seconds (stopped/cancelled).")
 
-                if self.running and flow_iteration < len(flows):
-                    if self.config.flow_cycle_delay_ms is not None:
-                        rest_duration_s = max(self.config.flow_cycle_delay_ms / 1000.0, 0.001)
-                    else:
-                        min_rest_s = self.config.min_sleep_ms / 1000.0
-                        max_rest_s = self.config.max_sleep_ms / 1000.0
-                        if min_rest_s > max_rest_s:
-                            min_rest_s = max_rest_s
-                        rest_duration_s = random.uniform(min_rest_s, max_rest_s)
-                        if rest_duration_s <= 0.001:
-                            rest_duration_s = 0.001
-                    logger.info(f"{user_log_prefix}: Next flow in {rest_duration_s:.2f}s")
-                    try:
-                        await asyncio.sleep(rest_duration_s)
-                    except asyncio.CancelledError:
-                        logger.info(f"{user_log_prefix}: Task cancelled during rest period.")
-                        self.running = False
-                        break
+                    if self.running:
+                        if self.config.flow_cycle_delay_ms is not None:
+                            rest_duration_s = max(self.config.flow_cycle_delay_ms / 1000.0, 0.001)
+                        else:
+                            min_rest_s = self.config.min_sleep_ms / 1000.0
+                            max_rest_s = self.config.max_sleep_ms / 1000.0
+                            if min_rest_s > max_rest_s:
+                                min_rest_s = max_rest_s
+                            rest_duration_s = random.uniform(min_rest_s, max_rest_s)
+                            if rest_duration_s <= 0.001:
+                                rest_duration_s = 0.001
+                        logger.info(f"{user_log_prefix}: Next flow in {rest_duration_s:.2f}s")
+                        try:
+                            await asyncio.sleep(rest_duration_s)
+                        except asyncio.CancelledError:
+                            logger.info(f"{user_log_prefix}: Task cancelled during rest period.")
+                            self.running = False
+                            break
 
         except asyncio.CancelledError:
             logger.info(f"{user_log_prefix}: Task received cancellation signal.")

--- a/tests/unit/test_flow_runner.py
+++ b/tests/unit/test_flow_runner.py
@@ -759,3 +759,94 @@ def test_substitute_variables_unquoted_and_malformed(base_config, empty_flow):
         runner._substitute_variables("##VAR:unquoted:name:extra##", context)
         is None
     )
+
+
+@pytest.mark.asyncio
+async def test_simulate_user_lifecycle_moves_to_next_flow_on_failure(base_config):
+    flow1 = FlowMap(name="flow1", steps=[])
+    flow2 = FlowMap(name="flow2", steps=[])
+    metrics = Metrics()
+    metrics.increment = AsyncMock()
+    metrics.record_flow_duration = AsyncMock()
+    runner = FlowRunner(base_config, flow1, metrics, flowmaps=[flow1, flow2])
+    runner.config.min_sleep_ms = runner.config.max_sleep_ms = 0
+    runner.running = True
+
+    class DummyConnector:
+        closed = False
+
+        async def close(self):
+            self.closed = True
+
+    connector = DummyConnector()
+    runner.create_aiohttp_connector = MagicMock(return_value=connector)
+
+    dummy_session = MagicMock()
+    dummy_session.closed = False
+
+    async def close_session():
+        dummy_session.closed = True
+
+    dummy_session.close = AsyncMock(side_effect=close_session)
+    runner.create_session = MagicMock(return_value=dummy_session)
+
+    call_errors = []
+
+    async def fake_execute_steps(steps, session, base_headers, flow_headers, context, depth=0):
+        if not call_errors:
+            set_value_in_context(context, "flow_error", "boom")
+        else:
+            runner.running = False
+        call_errors.append(get_value_from_context(context, "flow_error"))
+
+    runner._execute_steps = AsyncMock(side_effect=fake_execute_steps)
+
+    await runner.simulate_user_lifecycle(user_id=0)
+
+    assert call_errors[0] == "boom"
+    assert call_errors[1] is None
+
+
+@pytest.mark.asyncio
+async def test_simulate_user_lifecycle_restarts_single_flow_after_failure(base_config):
+    flow = FlowMap(name="solo", steps=[])
+    metrics = Metrics()
+    metrics.increment = AsyncMock()
+    metrics.record_flow_duration = AsyncMock()
+    runner = FlowRunner(base_config, flow, metrics)
+    runner.config.min_sleep_ms = runner.config.max_sleep_ms = 0
+    runner.running = True
+
+    class DummyConnector:
+        closed = False
+
+        async def close(self):
+            self.closed = True
+
+    connector = DummyConnector()
+    runner.create_aiohttp_connector = MagicMock(return_value=connector)
+
+    dummy_session = MagicMock()
+    dummy_session.closed = False
+
+    async def close_session():
+        dummy_session.closed = True
+
+    dummy_session.close = AsyncMock(side_effect=close_session)
+    runner.create_session = MagicMock(return_value=dummy_session)
+
+    call_errors = []
+
+    async def fake_execute_steps(steps, session, base_headers, flow_headers, context, depth=0):
+        if not call_errors:
+            set_value_in_context(context, "flow_error", "boom")
+        else:
+            runner.running = False
+        call_errors.append(get_value_from_context(context, "flow_error"))
+
+    runner._execute_steps = AsyncMock(side_effect=fake_execute_steps)
+
+    await runner.simulate_user_lifecycle(user_id=0)
+
+    assert call_errors[0] == "boom"
+    assert call_errors[1] is None


### PR DESCRIPTION
## Summary
- Run all flowmaps in a loop so FlowRunner continues after a failed flow and restarts single flows
- Invoke `on_iteration_start` callback for iterations beyond the first
- Add unit tests for multi-flow and single-flow failure recovery

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'container_control')*
- `pytest tests/unit/test_flow_runner.py`


------
https://chatgpt.com/codex/tasks/task_b_68c6883c91cc8320b693850cccd46c1f