### PR TITLE
Add reset threshold for flow metrics

### DIFF
--- a/flow_runner.py
+++ b/flow_runner.py
@@ -243,6 +243,8 @@ class Metrics:
     Tracks RPS using a rolling window and computes average flow duration.
     Thread-safe using asyncio.Lock.
     """
+    MAX_FLOW_COUNT = 10_000
+
     def __init__(self):
         self.lock = asyncio.Lock()
         self.request_timestamps = deque()
@@ -290,6 +292,10 @@ class Metrics:
         async with self.lock:
             self.flow_duration_sum += duration_seconds
             self.flow_count += 1
+            if self.flow_count >= self.MAX_FLOW_COUNT:
+                logger.debug("Resetting flow duration metrics after reaching threshold")
+                self.flow_duration_sum = 0.0
+                self.flow_count = 0
 
     async def get_average_flow_duration_ms(self) -> float:
         """Return the average duration of completed flows in milliseconds."""

--- a/tests/unit/test_flow_runner.py
+++ b/tests/unit/test_flow_runner.py
@@ -105,6 +105,17 @@ def test_init_override_step_url_host_false(empty_flow):
     assert runner.config.override_step_url_host is False
 
 
+@pytest.mark.asyncio
+async def test_metrics_resets_after_threshold():
+    metrics = Metrics()
+    metrics.MAX_FLOW_COUNT = 3
+    for _ in range(3):
+        await metrics.record_flow_duration(1.0)
+    assert metrics.flow_count == 0
+    assert metrics.flow_duration_sum == 0.0
+    assert await metrics.get_average_flow_duration_ms() == 0.0
+
+
 def test_get_value_from_context_basic():
     ctx = {"a": {"b": [1, {"c": 2}]}}
     assert get_value_from_context(ctx, "a.b[1].c") == 2


### PR DESCRIPTION
## Summary
- prevent `Metrics.flow_count` from growing without bound by resetting after 10k flows
- cover metrics reset behavior with unit test

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'container_control')*

------
https://chatgpt.com/codex/tasks/task_b_68c68fc31d9083209725b224647dad13