### PR TITLE
Improve flow assignment and array extraction

### DIFF
--- a/flow_runner.py
+++ b/flow_runner.py
@@ -583,6 +583,12 @@ class FlowRunner:
         # Mapping of flowmap identity to an asyncio.Lock to prevent concurrent execution of the same flow
         self._flow_locks: Dict[int, asyncio.Lock] = {id(flow): asyncio.Lock() for flow in self.flowmaps}
 
+        # Queue of flows used when concurrency is disallowed. Acts as a stack
+        # (FILO) so the most recently returned flow is executed first.
+        self._available_flows: deque[FlowMap] = deque()
+        self._flow_assignment_lock = asyncio.Lock()
+        self._refresh_available_flows()
+
         self.configure_logging(self.config.debug)
 
         # --- Header/User-Agent Setup (Restored actual lists) ---
@@ -768,6 +774,26 @@ class FlowRunner:
             cookie_jar=None, # Explicitly disable automatic cookie handling per session
             connector_owner=False # Important: Connector is shared and managed outside
         )
+
+    def _refresh_available_flows(self) -> None:
+        """Shuffle and populate the available flow stack."""
+        flows = list(self.flowmaps)
+        random.shuffle(flows)
+        self._available_flows.extend(flows)
+
+    async def _acquire_flow(self) -> Optional[FlowMap]:
+        """Pop the next flow for execution when concurrency is disabled."""
+        while self.running:
+            async with self._flow_assignment_lock:
+                if self._available_flows:
+                    return self._available_flows.pop()
+            await asyncio.sleep(0.01)
+        return None
+
+    async def _release_flow(self, flow: FlowMap) -> None:
+        """Return a flow to the stack after execution."""
+        async with self._flow_assignment_lock:
+            self._available_flows.append(flow)
 
     async def start_generating(self):
         """Start all simulated user tasks and run continuously until stopped."""
@@ -1354,8 +1380,19 @@ class FlowRunner:
                           logger.warning(f"Invalid extraction path '{path_expr}' for variable '{var_name}'. Needs key after 'body.'.")
                           extracted_value = None
                      else:
-                          # Use get_value_from_context on the response body
                           extracted_value = get_value_from_context(response_data, effective_path)
+                elif path_lower.startswith("body["):
+                     source_description = "body"
+                     effective_path = path_expr[len("body"):]
+                     if not effective_path:
+                          logger.warning(f"Invalid extraction path '{path_expr}' for variable '{var_name}'. Needs index after 'body'.")
+                          extracted_value = None
+                     else:
+                          extracted_value = get_value_from_context(response_data, effective_path)
+                elif path_lower.startswith("["):
+                     source_description = "body"
+                     effective_path = path_expr
+                     extracted_value = get_value_from_context(response_data, effective_path)
                 else:
                      # Default: Assume path refers to the response body
                      # This now correctly handles the literal "status" (not ".status") as a body path
@@ -2077,19 +2114,20 @@ class FlowRunner:
 
             overall_flow_iteration = 0
             while self.running:
-                flows = list(self.flowmaps)
-                random.shuffle(flows)
+                if self.config.allow_flow_concurrency:
+                    flows = list(self.flowmaps)
+                    random.shuffle(flows)
+                else:
+                    flow = await self._acquire_flow()
+                    if flow is None:
+                        await asyncio.sleep(0.01)
+                        continue
+                    flows = [flow]
                 executed_any = False
 
                 for flow_iteration, flow in enumerate(flows, start=1):
                     if not self.running:
                         break
-                    lock = None
-                    if not self.config.allow_flow_concurrency:
-                        lock = self._flow_locks.get(id(flow))
-                        if lock.locked():
-                            continue
-                        await lock.acquire()
                     executed_any = True
                     overall_flow_iteration += 1
                     flow_instance_start_time = time.monotonic()
@@ -2178,8 +2216,8 @@ class FlowRunner:
                         if session and not session.closed:
                             await session.close()
                             logger.debug(f"{user_log_prefix} (Flow {flow_iteration}): Session closed.")
-                        if lock is not None and lock.locked():
-                            lock.release()
+                        if not self.config.allow_flow_concurrency:
+                            await self._release_flow(flow)
 
                         flow_instance_end_time = time.monotonic()
                         flow_duration = flow_instance_end_time - flow_instance_start_time

--- a/tests/unit/test_flow_runner.py
+++ b/tests/unit/test_flow_runner.py
@@ -159,6 +159,20 @@ def test_extract_data_non_dict_body(base_config, empty_flow):
     assert ctx["user"] is None
 
 
+def test_extract_data_root_list(base_config, empty_flow):
+    runner = make_runner(base_config, empty_flow)
+    ctx: Dict[str, Any] = {}
+    body = [{"order_id": 1}, {"order_id": 2}]
+    headers = {}
+    rules = {
+        "first": "body.[0].order_id",
+        "second": "body[1].order_id",
+    }
+    runner._extract_data(body, rules, ctx, 200, headers)
+    assert ctx["first"] == 1
+    assert ctx["second"] == 2
+
+
 @pytest.mark.asyncio
 @pytest.mark.parametrize(
     "operator,left,right,expected",
@@ -900,3 +914,48 @@ async def test_flow_concurrency_disabled(monkeypatch, empty_flow):
     await asyncio.gather(task1, task2, stopper)
 
     assert concurrent["max"] == 1
+
+
+@pytest.mark.asyncio
+async def test_flow_distribution_without_concurrency(monkeypatch):
+    flow1 = FlowMap(name="flow1", description=None, headers=None, steps=[], staticVars={"fname": "flow1"})
+    flow2 = FlowMap(name="flow2", description=None, headers=None, steps=[], staticVars={"fname": "flow2"})
+    cfg = ContainerConfig(
+        flow_target_url="http://example.com",
+        sim_users=2,
+        allow_flow_concurrency=False,
+        min_sleep_ms=0,
+        max_sleep_ms=0,
+    )
+    metrics = Metrics()
+    metrics.increment = AsyncMock()
+    metrics.record_flow_duration = AsyncMock()
+    runner = FlowRunner(cfg, flow1, metrics, flowmaps=[flow1, flow2])
+    runner.running = True
+
+    concurrent = {"running": set(), "max": 0, "duplicate": False}
+
+    async def fake_execute_steps(steps, session, base_headers, flow_headers, context, depth=0):
+        fname = context.get("fname")
+        if fname in concurrent["running"]:
+            concurrent["duplicate"] = True
+        concurrent["running"].add(fname)
+        concurrent["max"] = max(concurrent["max"], len(concurrent["running"]))
+        await asyncio.sleep(0.05)
+        concurrent["running"].remove(fname)
+
+    monkeypatch.setattr(runner, "_execute_steps", fake_execute_steps)
+    monkeypatch.setattr(runner, "create_aiohttp_connector", lambda: MagicMock(closed=False, close=AsyncMock()))
+    monkeypatch.setattr(runner, "create_session", lambda conn: MagicMock(closed=False, close=AsyncMock()))
+
+    async def stop_later():
+        await asyncio.sleep(0.2)
+        runner.running = False
+
+    task1 = asyncio.create_task(runner.simulate_user_lifecycle(0))
+    task2 = asyncio.create_task(runner.simulate_user_lifecycle(1))
+    stopper = asyncio.create_task(stop_later())
+    await asyncio.gather(task1, task2, stopper)
+
+    assert not concurrent["duplicate"]
+    assert concurrent["max"] == 2


### PR DESCRIPTION
## Summary
- assign flows to simulated users via a shared stack when concurrency is disabled
- support extraction paths that index into root-level arrays
- cover flow distribution and list extraction with new unit tests

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'container_control')*
- `pytest tests/unit/test_flow_runner.py`


------
https://chatgpt.com/codex/tasks/task_b_68c6b464a4dc8320a5747d91e30c6dd5