### PR TITLE
Improve logging configuration and RPS metrics

### DIFF
--- a/flow_runner.py
+++ b/flow_runner.py
@@ -268,15 +268,16 @@ class Metrics:
         self.flow_count = 0
 
     async def increment(self):
-        """Record that a request was made (for RPS)."""
+        """Record that a request was made and refresh cached RPS."""
         now = time.monotonic()
         async with self.lock:
             self.request_timestamps.append(now)
-            # Optimization: Only prune when necessary (e.g., during get_rps) or periodically?
-            # For simplicity, prune here.
             one_second_ago = now - 1.0
             while self.request_timestamps and self.request_timestamps[0] < one_second_ago:
                 self.request_timestamps.popleft()
+            # Keep snapshot fresh for sync readers (adapter)
+            self.last_rps_value = float(len(self.request_timestamps))
+            self.last_rps_update_time = now
 
     async def get_rps(self) -> float:
         """Return the approximate RPS over the last 1 second."""
@@ -699,15 +700,13 @@ class FlowRunner:
         else:
             logger.info(f"{len(self.flowmaps)} flowmaps loaded")
 
-    def configure_logging(self, debug: bool):
-        """Configures the logger level based on the debug flag."""
-        log_level = logging.DEBUG if debug else logging.INFO
-        # Configure our specific logger
-        logger.setLevel(log_level)
-        # Also configure handlers attached to our logger
-        for handler in logger.handlers:
-            handler.setLevel(log_level)
-        logger.info(f"Flow Generator logging level set to {logging.getLevelName(log_level)}")
+    def configure_logging(self, debug: bool) -> None:
+        """Configures logger and handler levels based on debug flag."""
+        level = logging.DEBUG if debug else logging.INFO
+        logger.setLevel(level)
+        for h in logger.handlers:
+            h.setLevel(level)
+        logger.debug("Logging configured", extra={"debug": debug})
 
     def create_aiohttp_connector(self) -> aiohttp.BaseConnector:
         """Creates an aiohttp connector, applying DNS override if configured."""

--- a/tests/unit/test_flow_runner.py
+++ b/tests/unit/test_flow_runner.py
@@ -56,7 +56,10 @@ from flow_runner import (
     ConditionData,
     Metrics,
     StartRequest,
-    get_value_from_context, _MISSING, set_value_in_context,
+    get_value_from_context,
+    _MISSING,
+    set_value_in_context,
+    logger as fr_logger,
 )
 
 
@@ -68,6 +71,20 @@ def base_config() -> ContainerConfig:
 @pytest.fixture
 def empty_flow() -> FlowMap:
     return FlowMap(name="test", steps=[], staticVars={"static": "val"})
+
+
+def test_configure_logging_debug(empty_flow):
+    cfg = ContainerConfig(flow_target_url="http://example.com", sim_users=1, debug=True)
+    make_runner(cfg, empty_flow)
+    assert fr_logger.level == logging.DEBUG
+    assert all(h.level == logging.DEBUG for h in fr_logger.handlers)
+
+
+def test_configure_logging_info(empty_flow):
+    cfg = ContainerConfig(flow_target_url="http://example.com", sim_users=1, debug=False)
+    make_runner(cfg, empty_flow)
+    assert fr_logger.level == logging.INFO
+    assert all(h.level == logging.INFO for h in fr_logger.handlers)
 
 
 def make_runner(config: ContainerConfig, flow: FlowMap) -> FlowRunner:
@@ -114,6 +131,17 @@ async def test_metrics_resets_after_threshold():
     assert metrics.flow_count == 0
     assert metrics.flow_duration_sum == 0.0
     assert await metrics.get_average_flow_duration_ms() == 0.0
+
+
+@pytest.mark.asyncio
+async def test_metrics_increment_updates_rps():
+    metrics = Metrics()
+    await metrics.increment()
+    await metrics.increment()
+    assert metrics.last_rps_value >= 1
+    await asyncio.sleep(1.1)
+    await metrics.get_rps()
+    assert metrics.last_rps_value == 0.0
 
 
 def test_get_value_from_context_basic():


### PR DESCRIPTION
## Summary
- ensure logging handler respects debug flag via configure_logging
- update metrics snapshot on each increment for accurate RPS sampling
- add tests verifying logging levels and RPS caching behavior

## Testing
- `pytest tests/unit/test_flow_runner.py`
- `pytest tests/e2e/test_container_control_api.py` *(fails: ModuleNotFoundError: No module named 'container_control')*
- `python -m pip install container-control` *(fails: No matching distribution found)*

------
https://chatgpt.com/codex/tasks/task_b_68c6dd7e924483208c0022f6a675735a